### PR TITLE
basic vga mode 13 driver implemented

### DIFF
--- a/inc/vga13h.asm
+++ b/inc/vga13h.asm
@@ -1,0 +1,99 @@
+;
+; VGA mode 13h video driver for COM flat files
+; Fabiano Salles, 2020
+; http://programmingdrops.com
+;
+
+
+
+; -------------------------------------------------------
+;  GENERAL PURPOSE ROUTINES
+; -------------------------------------------------------		
+
+; set_pixel - Render single pixel into offscreen buffer 
+; Input: 
+;   AL = color 
+;   BX = y 
+;   DI = x 
+;   ES = offscreen buffer segment 
+;------------------------------------------------------------------------ 
+set_pixel: 
+    pusha 
+    shl		bx, 6 
+    add		di, bx 
+    shl		bx, 2 
+    add		di, bx 
+    mov		byte[es:di],al 
+    popa 
+    ret 
+		
+		
+;------------------------------------------------------------------------ 
+; line_h - Render horizontal line into offscreen buffer 
+; Input: 
+;   AL = color 
+;   BX = y 
+;   DI = x 
+;   CX = length 
+;   ES = offscreen buffer segment 
+;------------------------------------------------------------------------ 
+line_h: 
+    pusha 
+    shl		bx, 6 
+    add		di, bx 
+    shl		bx, 2 
+    add		di, bx 
+    rep		stosb 
+    popa 
+    ret 
+		
+;------------------------------------------------------------------------ 
+; line_v - Render vertical line into offscreen buffer 
+; 
+; Input: 
+;   AL = color 
+;   BX = y 
+;   DI = x 
+;   CX = length 
+;   ES = offscreen buffer segment 
+;------------------------------------------------------------------------ 
+line_v: 
+    pusha 
+    shl     bx, 6 
+    add     di, bx 
+    shl     bx, 2 
+    add     di, bx 
+.loop: 
+    mov     byte[es:di],al 
+    add     di,320 
+    loop    .loop 
+    popa 
+    ret 
+
+;------------------------------------------------------------------------ 
+; fill_rect - Renders color filled recatngle into offscreen buffer 
+; Input: 
+;   BX = y 
+;   DI = x 
+;   CX = width 
+;   DX = height 
+;   AL = color 
+;   ES = offscreen buffer segment 
+;------------------------------------------------------------------------ 
+fill_rect: 
+    pusha 
+    mov     si,320 
+    sub     si, cx  ; SI = offset to next scan line start 
+    shl     bx, 6 
+    add     di, bx 
+    shl     bx, 2 
+    add     di, bx 
+.loop: 
+    push    cx 
+    rep     stosb 
+    pop     cx 
+    add     di, si ; advance offset to next scan line start 
+    sub     dx, 1  ; move up to the next y position 
+    jnz     .loop 
+    popa 
+    ret 		

--- a/inc/vga13h.inc
+++ b/inc/vga13h.inc
@@ -1,0 +1,132 @@
+;
+; VGA mode 13h video driver for COM flat files
+; Fabiano Salles, 2020
+; http://programmingdrops.com
+;
+
+
+; -------------------------------------------------------
+;  DEFINES
+; -------------------------------------------------------		
+
+OFFSCREEN_BASE   		equ 0x1000
+OFFSCREEN_SEGMENT		equ fs
+VGA_BASE				equ 0xA000
+VGA_SEGMENT				equ gs
+VGA_WORDS_COUNT			equ 0x7D00  ; number of words in display memory (320 * 200 / 2) 	
+USE_VSYNC				equ 0		; 0=disabled, 1=enabled 
+SCREEN_W			    equ 320
+SCREEN_H			    equ 200
+MAXX					equ 320-1
+MAXY					equ 200-1
+
+; default color pallete
+COLOR_BLACK			equ 0x00
+COLOR_BLUE			equ 0x01
+COLOR_GREEN			equ 0x02
+COLOR_CYAN			equ 0x03
+COLOR_RED			equ 0x04
+COLOR_MAGENTA		equ 0x05
+COLOR_BORWN			equ 0x06
+COLOR_LGRAY			equ 0x07	
+COLOR_LDGRAY		equ 0x08
+COLOR_LBLUE			equ 0x09
+COLOR_LGREEN		equ 0x0A
+COLOR_LCYAN			equ 0x0B
+COLOR_LMAGENTA		equ 0x0C	 
+COLOR_YELLOW		equ 0x0D
+COLOR_WHITE			equ 0x0E
+
+;
+; assuming cs = ds = ss = sp = ax
+; 
+init_graphics:
+   add	ax, OFFSCREEN_BASE  	; Offscreen buffer segment 
+   mov	OFFSCREEN_SEGMENT, ax   ;
+   mov	ax, VGA_BASE      		; Video memory segment 
+   mov	VGA_SEGMENT, ax 		; will be in gs
+                                ; Setup normal string direction flag (string instructions increment pointers)
+   mov  ax, 0x0013 			    ; Enter 320x200 graphics video mode 
+   int	0x10      				; invoke BIOS VIDEO service 
+   ret
+
+
+;
+; clears the offscreen buffer
+; reads color parameter from ax
+;
+clear_back_buffer:
+   push ax
+   mov  ax, OFFSCREEN_SEGMENT  ; get offscreen buffer segment into ES 
+   mov  es, ax 
+   xor  di, di     			   ; initial destination offset 
+   pop  ax                     ; load bg color from stack into al, ah
+   mov  cx, VGA_WORDS_COUNT    ; number of words in display memory (320 * 200 / 2) 
+   rep  stosw     			   ; write two pixels each pass 
+   ret
+	
+
+swap_buffers:
+	; Preload registers for fast swap 
+	; once vertical reset is detected 
+	mov  ax, OFFSCREEN_SEGMENT  
+	mov  ds, ax 
+	xor  si, si 		
+	mov  ax, VGA_SEGMENT
+	mov  es, ax 
+	xor  di, di 		
+	mov  cx, VGA_WORDS_COUNT ; number of words to move (320 * 200 / 2) 	
+	 
+if USE_VSYNC    ; Wait for vertical reset
+	mov  dx, 0x03DA 
+    .vend:  
+        in   al, dx 
+        test al, 0x08 
+        jz   vend 
+    .vres:  
+        in   al, dx 
+        test al, 0x08 
+        jnz  vres 
+end if
+ 
+	rep  movsw 	 ; copy offscreen buffer into video memory 
+	mov  ax, cs  ; Restore data segment register 
+	mov  ds, ax 	
+    ret
+
+
+; -------------------------------------------------------
+;  MACROS
+; -------------------------------------------------------	
+macro clear_screen color{
+    mov al, color
+    mov ah, color
+    call clear_back_buffer
+}
+
+macro set_draw_color color{
+    mov 	al, color
+}			
+        
+macro vert_line x, y, l{    
+    mov		di, x
+    mov 	bx, y
+    mov 	cx, l
+    call 	line_v
+}
+
+macro horiz_line x, y, l{
+    mov 	di, x
+    mov 	bx, y
+    mov		cx, l
+    call	line_h
+}
+
+macro fill_rect x, y, w, h{
+    mov		di, x
+    mov		bx, y
+    mov		cx, w
+    mov    	dx, h
+    call	fill_rect
+}
+

--- a/test_vga.asm
+++ b/test_vga.asm
@@ -1,0 +1,26 @@
+;
+; Simple test program to change to VGA mode 13h 
+; https://programmingdrops.com
+;
+
+format binary       ; flat binary file format
+use16 				; 16bit file
+org	0x0100          ; all COM files adresses must be relative to 0x100 memory offset
+jmp start
+
+include 'inc/vga13h.inc'
+
+start:
+   cli                      ; disable interrups
+   mov	ax, cs              ; code,data,stack share same segment 
+   mov	ds, ax 
+   mov	ss, ax 
+   xor	sp, sp      
+   cld                      ; clear direction flag for string instructions
+   sti                      ; reenable interrupts
+   call init_graphics       ; init VGA mode 13h 
+
+main:
+    clear_screen COLOR_LDGRAY
+    call swap_buffers
+    jmp main


### PR DESCRIPTION
A basic vga mode 13h graphics driver was implemented.
There is a sample program test_vga.asm which initializes the graphics mode and shows a gray background.
This program supports:
 
- VGA mode 13h
- double buffering

Here is a snapshot of it running on DOSBox
![image](https://user-images.githubusercontent.com/11824045/89115728-ef4df000-d461-11ea-9b02-79a1b08625f3.png)
